### PR TITLE
Completed Part2

### DIFF
--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
+		E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF052BDAF93D00C00693 /* ImagePicker.swift */; };
 		E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */; };
 		E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401EB2BD5A7050058E67B /* PhotosListView.swift */; };
 		E4C401EE2BD5A7060058E67B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4C401ED2BD5A7060058E67B /* Assets.xcassets */; };
@@ -21,6 +22,7 @@
 /* Begin PBXFileReference section */
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
+		E434FF052BDAF93D00C00693 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		E4C401E62BD5A7050058E67B /* Camera Photos SwiftData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Camera Photos SwiftData.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera_Photos_SwiftDataApp.swift; sourceTree = "<group>"; };
 		E4C401EB2BD5A7050058E67B /* PhotosListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosListView.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				E4C401FB2BD5AE6F0058E67B /* Constants.swift */,
+				E434FF052BDAF93D00C00693 /* ImagePicker.swift */,
 			);
 			path = ImagePicker_Camera;
 			sourceTree = "<group>";
@@ -175,6 +178,7 @@
 				E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */,
 				E4C401F92BD5ACAD0058E67B /* SampleModel.swift in Sources */,
 				E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */,
+				E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */,
 				E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */,
 				E4C401FC2BD5AE6F0058E67B /* Constants.swift in Sources */,
 			);

--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */; };
 		E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401EB2BD5A7050058E67B /* PhotosListView.swift */; };
 		E4C401EE2BD5A7060058E67B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4C401ED2BD5A7060058E67B /* Assets.xcassets */; };
@@ -17,6 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E4C401E62BD5A7050058E67B /* Camera Photos SwiftData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Camera Photos SwiftData.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera_Photos_SwiftDataApp.swift; sourceTree = "<group>"; };
 		E4C401EB2BD5A7050058E67B /* PhotosListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosListView.swift; sourceTree = "<group>"; };
@@ -39,6 +41,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E434FF002BDAF25000C00693 /* Model Edits */ = {
+			isa = PBXGroup;
+			children = (
+				E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */,
+			);
+			path = "Model Edits";
+			sourceTree = "<group>";
+		};
 		E4C401DD2BD5A7050058E67B = {
 			isa = PBXGroup;
 			children = (
@@ -62,6 +72,7 @@
 				E4C401EB2BD5A7050058E67B /* PhotosListView.swift */,
 				E4C401FD2BD5B42A0058E67B /* SampleView.swift */,
 				E4C401F82BD5ACAD0058E67B /* SampleModel.swift */,
+				E434FF002BDAF25000C00693 /* Model Edits */,
 				E4C401FA2BD5AE5E0058E67B /* ImagePicker_Camera */,
 				E4C401ED2BD5A7060058E67B /* Assets.xcassets */,
 				E4C401EF2BD5A7060058E67B /* Camera_Photos_SwiftData.entitlements */,
@@ -157,6 +168,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4C401FE2BD5B42A0058E67B /* SampleView.swift in Sources */,
+				E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */,
 				E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */,
 				E4C401F92BD5ACAD0058E67B /* SampleModel.swift in Sources */,
 				E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */,

--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
 		E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF052BDAF93D00C00693 /* ImagePicker.swift */; };
+		E434FF082BDAFDBE00C00693 /* ModelFormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF072BDAFDBE00C00693 /* ModelFormType.swift */; };
 		E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */; };
 		E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401EB2BD5A7050058E67B /* PhotosListView.swift */; };
 		E4C401EE2BD5A7060058E67B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4C401ED2BD5A7060058E67B /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
 		E434FF052BDAF93D00C00693 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
+		E434FF072BDAFDBE00C00693 /* ModelFormType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFormType.swift; sourceTree = "<group>"; };
 		E4C401E62BD5A7050058E67B /* Camera Photos SwiftData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Camera Photos SwiftData.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera_Photos_SwiftDataApp.swift; sourceTree = "<group>"; };
 		E4C401EB2BD5A7050058E67B /* PhotosListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosListView.swift; sourceTree = "<group>"; };
@@ -50,6 +52,7 @@
 			children = (
 				E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */,
 				E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */,
+				E434FF072BDAFDBE00C00693 /* ModelFormType.swift */,
 			);
 			path = "Model Edits";
 			sourceTree = "<group>";
@@ -177,6 +180,7 @@
 				E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */,
 				E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */,
 				E4C401F92BD5ACAD0058E67B /* SampleModel.swift in Sources */,
+				E434FF082BDAFDBE00C00693 /* ModelFormType.swift in Sources */,
 				E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */,
 				E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */,
 				E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */,

--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
+		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
 		E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */; };
 		E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C401EB2BD5A7050058E67B /* PhotosListView.swift */; };
 		E4C401EE2BD5A7060058E67B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4C401ED2BD5A7060058E67B /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
+		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
 		E4C401E62BD5A7050058E67B /* Camera Photos SwiftData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Camera Photos SwiftData.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4C401E92BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera_Photos_SwiftDataApp.swift; sourceTree = "<group>"; };
 		E4C401EB2BD5A7050058E67B /* PhotosListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosListView.swift; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 			isa = PBXGroup;
 			children = (
 				E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */,
+				E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */,
 			);
 			path = "Model Edits";
 			sourceTree = "<group>";
@@ -172,6 +175,7 @@
 				E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */,
 				E4C401F92BD5ACAD0058E67B /* SampleModel.swift in Sources */,
 				E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */,
+				E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */,
 				E4C401FC2BD5AE6F0058E67B /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Camera Photos SwiftData/ImagePicker_Camera/ImagePicker.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/ImagePicker.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Marcin Jędrzejak on 25/04/2024.
 //
+// Additional resource - ImagePicker Gist: https://gist.github.com/StewartLynch/45304cd2cb640f7c334e392e059e2a57
 
 import SwiftUI
 import PhotosUI

--- a/Camera Photos SwiftData/ImagePicker_Camera/ImagePicker.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/ImagePicker.swift
@@ -1,0 +1,48 @@
+//
+//  ImagePicker.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/04/2024.
+//
+
+import SwiftUI
+import PhotosUI
+
+
+@Observable
+class ImagePicker {
+    
+    var image: Image?
+    var images: [Image] = []
+  
+  // Change the UpdateEditFormViewModel to match the name of your own ViewModel
+    var vm: UpdateEditFormViewModel?
+    
+    func setup(_ vm: UpdateEditFormViewModel) {
+        self.vm = vm
+    }
+    var imageSelection: PhotosPickerItem? {
+        didSet {
+            if let imageSelection {
+                Task {
+                    try await loadTransferable(from: imageSelection)
+                }
+            }
+        }
+    }
+    
+    @MainActor
+    func loadTransferable(from imageSelection: PhotosPickerItem?) async throws {
+        do {
+            if let data = try await imageSelection?.loadTransferable(type: Data.self) {
+                vm?.data = data
+                if let uiImage = UIImage(data: data) {
+                    self.image = Image(uiImage: uiImage)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+            image = nil
+        }
+    }
+}

--- a/Camera Photos SwiftData/Model Edits/ModelFormType.swift
+++ b/Camera Photos SwiftData/Model Edits/ModelFormType.swift
@@ -1,0 +1,26 @@
+//
+//  ModelFormType.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/04/2024.
+//
+
+import SwiftUI
+
+enum ModelFormType: Identifiable, View {
+    case new
+    case update(SampleModel)
+    
+    var id: String {
+        String(describing: self)
+    }
+
+    var body: some View {
+        switch self {
+        case .new:
+            UpdateEditFormView(vm: UpdateEditFormViewModel())
+        case .update(let sample):
+            UpdateEditFormView(vm: UpdateEditFormViewModel(sample: sample))
+        }
+    }
+}

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
@@ -7,12 +7,14 @@
 
 import SwiftUI
 import SwiftData
+import PhotosUI
 
 struct UpdateEditFormView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @State var vm: UpdateEditFormViewModel
-
+    @State private var imagePicker = ImagePicker()
+    
     var body: some View {
         NavigationStack {
             Form {
@@ -28,9 +30,55 @@ struct UpdateEditFormView: View {
                         Button("Camera", systemImage: "camera") {
                             
                         }
+                        PhotosPicker(selection: $imagePicker.imageSelection) {
+                            Label("Photos", systemImage: "photo")
+                        }
                     }
                     .foregroundStyle(.white)
                     .buttonStyle(.borderedProminent)
+                    Image(uiImage: vm.image)
+                        .resizable()
+                        .scaledToFill()
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .padding()
+                }
+            }
+            .onAppear {
+                imagePicker.setup(vm)
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        if vm.isUpdating {
+                            if let sample = vm.sample {
+                                if vm.image != Constants.placeholder {
+                                    sample.data = vm.image.jpegData(compressionQuality: 0.8)
+                                } else {
+                                    sample.data = nil
+                                }
+                                sample.name = vm.name
+                                dismiss()
+                            }
+                        } else {
+                            let newSample = SampleModel(name: vm.name)
+                            if vm.image != Constants.placeholder {
+                                newSample.data = vm.image.jpegData(compressionQuality: 0.8)
+                            } else {
+                                newSample.data = nil
+                            }
+                            modelContext.insert(newSample)
+                            dismiss()
+                        }
+                        
+                    } label: {
+                        Text(vm.isUpdating ? "Update" : "Add")
+                    }
+                    .disabled(vm.isDisabled)
                 }
             }
         }

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
@@ -1,0 +1,42 @@
+//
+//  UpdateEditFormView.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/04/2024.
+//
+
+import SwiftUI
+import SwiftData
+
+struct UpdateEditFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @State var vm: UpdateEditFormViewModel
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $vm.name)
+                VStack {
+                    if vm.data != nil {
+                        Button("Clear image") {
+                            vm.clearImage()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    HStack {
+                        Button("Camera", systemImage: "camera") {
+                            
+                        }
+                    }
+                    .foregroundStyle(.white)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    UpdateEditFormView(vm: UpdateEditFormViewModel())
+}

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
@@ -24,7 +24,7 @@ struct UpdateEditFormView: View {
                         Button("Clear image") {
                             vm.clearImage()
                         }
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(.bordered)
                     }
                     HStack {
                         Button("Camera", systemImage: "camera") {

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  UpdateEditFormViewModel.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/04/2024.
+//
+
+import UIKit
+
+class UpdateEditFormViewModel {
+    var name: String = ""
+    var data: Data?
+
+    var sample: SampleModel?
+
+    var image: UIImage {
+        if let data, let uiImage = UIImage(data: data) {
+            return uiImage
+        } else {
+            return Constants.placeholder
+        }
+    }
+
+    init() {}
+    init(sample: SampleModel) {
+        self.sample = sample
+        self.name = sample.name
+        self.data = sample.data
+    }
+
+    @MainActor
+    func clearImage() {
+        data = nil
+    }
+
+    var isUpdating: Bool { sample != nil }
+    var isDisabled: Bool { name.isEmpty }
+}

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@Observable
 class UpdateEditFormViewModel {
     var name: String = ""
     var data: Data?

--- a/Camera Photos SwiftData/PhotosListView.swift
+++ b/Camera Photos SwiftData/PhotosListView.swift
@@ -14,6 +14,7 @@ import SwiftData
 struct PhotosListView: View {
     @Query(sort: \SampleModel.name) var samples: [SampleModel]
     @Environment(\.modelContext) private var modelContext
+    @State private var formType: ModelFormType?
     var body: some View {
         NavigationStack {
             Group {
@@ -50,10 +51,11 @@ struct PhotosListView: View {
             .navigationTitle("Picker or Camera")
             .toolbar {
                 Button {
-                    
+                    formType = .new
                 } label: {
                     Image(systemName: "plus.circle.fill")
                 }
+                .sheet(item: $formType) { $0 }
             }
         }
     }

--- a/Camera Photos SwiftData/PhotosListView.swift
+++ b/Camera Photos SwiftData/PhotosListView.swift
@@ -6,6 +6,7 @@
 //
 
 // Link 1: https://www.youtube.com/watch?v=T7wf4DGPCHs&ab_channel=StewartLynch
+// Link 2: https://www.youtube.com/watch?v=WT7bYj80gJ0&ab_channel=StewartLynch
 
 import SwiftUI
 import SwiftData

--- a/Camera Photos SwiftData/SampleView.swift
+++ b/Camera Photos SwiftData/SampleView.swift
@@ -11,6 +11,7 @@ import SwiftData
 struct SampleView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @State private var formType: ModelFormType?
     let sample: SampleModel
     var body: some View {
         VStack {
@@ -23,12 +24,13 @@ struct SampleView: View {
                 .padding()
             HStack {
                 Button("Edit") {
+                    formType = .update(sample)
+                }
+                .sheet(item: $formType) { $0 }
+                Button("Delete", role: .destructive) {
                     modelContext.delete(sample)
                     try? modelContext.save()
                     dismiss()
-                }
-                Button("Delete", role: .destructive) {
-                    
                 }
             }
             .buttonStyle(.borderedProminent)


### PR DESCRIPTION
Completed Part2 video tutorial: 2. Camera Photos SwiftData: Update/Edit and PhotoPicker.

This is the second in a series of 3 videos where Stewart Lynch will show how to add a photos picker or choose,mand use a camera to take photos and persist those photos to a Swift Data data Store.

With presented video, I created a ViewModel and View for presenting both updates and the creation of new objects for my data store and use the PhotosUI photoPicker for choosing a photo from my photo album to update the data property in the SwiftData model.