### PR TITLE
Completed Part3 (final)

### DIFF
--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E42E76512C0164E100532CBE /* CameraPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76502C0164E100532CBE /* CameraPermission.swift */; };
 		E42E76532C01675900532CBE /* UIKitCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76522C01675900532CBE /* UIKitCamera.swift */; };
+		E42E76572C0178E800532CBE /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76562C0178E800532CBE /* ZoomableScrollView.swift */; };
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
 		E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF052BDAF93D00C00693 /* ImagePicker.swift */; };
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		E42E76502C0164E100532CBE /* CameraPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPermission.swift; sourceTree = "<group>"; };
 		E42E76522C01675900532CBE /* UIKitCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitCamera.swift; sourceTree = "<group>"; };
+		E42E76562C0178E800532CBE /* ZoomableScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
 		E434FF052BDAF93D00C00693 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				E4C401FB2BD5AE6F0058E67B /* Constants.swift */,
 				E434FF052BDAF93D00C00693 /* ImagePicker.swift */,
 				E42E76502C0164E100532CBE /* CameraPermission.swift */,
+				E42E76562C0178E800532CBE /* ZoomableScrollView.swift */,
 				E42E76522C01675900532CBE /* UIKitCamera.swift */,
 			);
 			path = ImagePicker_Camera;
@@ -192,6 +195,7 @@
 				E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */,
 				E42E76512C0164E100532CBE /* CameraPermission.swift in Sources */,
 				E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */,
+				E42E76572C0178E800532CBE /* ZoomableScrollView.swift in Sources */,
 				E4C401FC2BD5AE6F0058E67B /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E42E76512C0164E100532CBE /* CameraPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76502C0164E100532CBE /* CameraPermission.swift */; };
+		E42E76532C01675900532CBE /* UIKitCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76522C01675900532CBE /* UIKitCamera.swift */; };
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
 		E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF052BDAF93D00C00693 /* ImagePicker.swift */; };
@@ -23,6 +24,7 @@
 
 /* Begin PBXFileReference section */
 		E42E76502C0164E100532CBE /* CameraPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPermission.swift; sourceTree = "<group>"; };
+		E42E76522C01675900532CBE /* UIKitCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitCamera.swift; sourceTree = "<group>"; };
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
 		E434FF052BDAF93D00C00693 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				E4C401FB2BD5AE6F0058E67B /* Constants.swift */,
 				E434FF052BDAF93D00C00693 /* ImagePicker.swift */,
 				E42E76502C0164E100532CBE /* CameraPermission.swift */,
+				E42E76522C01675900532CBE /* UIKitCamera.swift */,
 			);
 			path = ImagePicker_Camera;
 			sourceTree = "<group>";
@@ -180,6 +183,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4C401FE2BD5B42A0058E67B /* SampleView.swift in Sources */,
+				E42E76532C01675900532CBE /* UIKitCamera.swift in Sources */,
 				E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */,
 				E4C401EC2BD5A7050058E67B /* PhotosListView.swift in Sources */,
 				E4C401F92BD5ACAD0058E67B /* SampleModel.swift in Sources */,

--- a/Camera Photos SwiftData.xcodeproj/project.pbxproj
+++ b/Camera Photos SwiftData.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E42E76512C0164E100532CBE /* CameraPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42E76502C0164E100532CBE /* CameraPermission.swift */; };
 		E434FF022BDAF26200C00693 /* UpdateEditFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */; };
 		E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */; };
 		E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434FF052BDAF93D00C00693 /* ImagePicker.swift */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E42E76502C0164E100532CBE /* CameraPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPermission.swift; sourceTree = "<group>"; };
 		E434FF012BDAF26200C00693 /* UpdateEditFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormViewModel.swift; sourceTree = "<group>"; };
 		E434FF032BDAF62F00C00693 /* UpdateEditFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEditFormView.swift; sourceTree = "<group>"; };
 		E434FF052BDAF93D00C00693 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 			children = (
 				E4C401FB2BD5AE6F0058E67B /* Constants.swift */,
 				E434FF052BDAF93D00C00693 /* ImagePicker.swift */,
+				E42E76502C0164E100532CBE /* CameraPermission.swift */,
 			);
 			path = ImagePicker_Camera;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				E434FF082BDAFDBE00C00693 /* ModelFormType.swift in Sources */,
 				E4C401EA2BD5A7050058E67B /* Camera_Photos_SwiftDataApp.swift in Sources */,
 				E434FF062BDAF93D00C00693 /* ImagePicker.swift in Sources */,
+				E42E76512C0164E100532CBE /* CameraPermission.swift in Sources */,
 				E434FF042BDAF62F00C00693 /* UpdateEditFormView.swift in Sources */,
 				E4C401FC2BD5AE6F0058E67B /* Constants.swift in Sources */,
 			);
@@ -318,6 +322,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Permission required to take photos with camera";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -356,6 +361,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Permission required to take photos with camera";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Camera Photos SwiftData/ImagePicker_Camera/CameraPermission.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/CameraPermission.swift
@@ -30,25 +30,25 @@ enum CameraPermission {
                 return "Use the photo album instead."
             }
         }
-
-        static func checkPermissions() -> CameraError? {
-            if UIImagePickerController.isSourceTypeAvailable(.camera) {
-                let authStatus = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
-                switch authStatus {
-                case .notDetermined:
-                    return nil
-                case .restricted:
-                    return nil
-                case .denied:
-                    return .unauthorized
-                case .authorized:
-                    return nil
-                @unknown default:
-                    return nil
-                }
-            } else {
-                return .unavailable
+    }
+    
+    static func checkPermissions() -> CameraError? {
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            let authStatus = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
+            switch authStatus {
+            case .notDetermined:
+                return nil
+            case .restricted:
+                return nil
+            case .denied:
+                return .unauthorized
+            case .authorized:
+                return nil
+            @unknown default:
+                return nil
             }
+        } else {
+            return .unavailable
         }
     }
 }

--- a/Camera Photos SwiftData/ImagePicker_Camera/CameraPermission.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/CameraPermission.swift
@@ -1,0 +1,54 @@
+//
+//  CameraPermission.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/05/2024.
+//
+
+import UIKit
+import AVFoundation
+
+enum CameraPermission {
+    enum CameraError: Error, LocalizedError {
+        case unauthorized
+        case unavailable
+        
+        var errorDescription: String? {
+            switch self {
+            case .unauthorized:
+                return NSLocalizedString("You have not authorized camera use", comment: "")
+            case .unavailable:
+                return NSLocalizedString("A camera is not available for this device", comment: "")
+            }
+        }
+        
+        var recommendedActions: String? {
+            switch self {
+            case .unauthorized:
+                return "Open Settings > Privacy and Security > Camera and turn on for this app."
+            case .unavailable:
+                return "Use the photo album instead."
+            }
+        }
+
+        static func checkPermissions() -> CameraError? {
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                let authStatus = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
+                switch authStatus {
+                case .notDetermined:
+                    return nil
+                case .restricted:
+                    return nil
+                case .denied:
+                    return .unauthorized
+                case .authorized:
+                    return nil
+                @unknown default:
+                    return nil
+                }
+            } else {
+                return .unavailable
+            }
+        }
+    }
+}

--- a/Camera Photos SwiftData/ImagePicker_Camera/UIKitCamera.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/UIKitCamera.swift
@@ -1,0 +1,43 @@
+//
+//  UIKitCamera.swift
+//  Camera Photos SwiftData
+//
+//  Created by Marcin Jędrzejak on 25/05/2024.
+//
+
+import SwiftUI
+
+struct UIKitCamera: UIViewControllerRepresentable {
+    @Binding var selectedImage: UIImage?
+    @Environment(\.dismiss) var dismiss
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        imagePicker.allowsEditing = false
+        imagePicker.sourceType = .camera
+        imagePicker.delegate = context.coordinator
+        return imagePicker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        var parent: UIKitCamera
+        init(parent: UIKitCamera) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                parent.selectedImage = image
+            }
+            parent.dismiss()
+        }
+    }
+}

--- a/Camera Photos SwiftData/ImagePicker_Camera/ZoomableScrollView.swift
+++ b/Camera Photos SwiftData/ImagePicker_Camera/ZoomableScrollView.swift
@@ -1,0 +1,60 @@
+//
+// Created for SwiftData Photo_Camera
+// by  Stewart Lynch on 2024-02-18
+//
+// Follow me on Mastodon: @StewartLynch@iosdev.space
+// Follow me on Threads: @StewartLynch (https://www.threads.net)
+// Follow me on X: https://x.com/StewartLynch
+// Follow me on LinkedIn: https://linkedin.com/in/StewartLynch
+// Subscribe on YouTube: https://youTube.com/@StewartLynch
+// Buy me a ko-fi:  https://ko-fi.com/StewartLynch
+
+
+import SwiftUI
+
+struct ZoomableScrollView<Content: View>: UIViewRepresentable {
+    
+  private var content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  func makeUIView(context: Context) -> UIScrollView {
+    // set up the UIScrollView
+    let scrollView = UIScrollView()
+    scrollView.delegate = context.coordinator  // for viewForZooming(in:)
+    scrollView.maximumZoomScale = 20
+    scrollView.minimumZoomScale = 1
+    scrollView.bouncesZoom = true
+    // create a UIHostingController to hold our SwiftUI content
+    let hostedView = context.coordinator.hostingController.view!
+    hostedView.translatesAutoresizingMaskIntoConstraints = true
+    hostedView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    hostedView.frame = scrollView.bounds
+    scrollView.addSubview(hostedView)
+    return scrollView
+  }
+
+  func makeCoordinator() -> Coordinator {
+    return Coordinator(hostingController: UIHostingController(rootView: self.content))
+  }
+
+  func updateUIView(_ uiView: UIScrollView, context: Context) {
+    // update the hosting controller's SwiftUI content
+    uiView.setZoomScale(1.0, animated: true)
+    context.coordinator.hostingController.rootView = self.content
+    assert(context.coordinator.hostingController.view.superview == uiView)
+  }
+
+  // Coordinator
+  class Coordinator: NSObject, UIScrollViewDelegate {
+    var hostingController: UIHostingController<Content>
+    init(hostingController: UIHostingController<Content>) {
+      self.hostingController = hostingController
+    }
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+      return hostingController.view
+    }
+  }
+}

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormView.swift
@@ -14,6 +14,8 @@ struct UpdateEditFormView: View {
     @Environment(\.modelContext) private var modelContext
     @State var vm: UpdateEditFormViewModel
     @State private var imagePicker = ImagePicker()
+    @State private var showCamera = false
+    @State private var cameraError: CameraPermission.CameraError?
     
     var body: some View {
         NavigationStack {
@@ -28,7 +30,22 @@ struct UpdateEditFormView: View {
                     }
                     HStack {
                         Button("Camera", systemImage: "camera") {
-                            
+                            if let error = CameraPermission.checkPermissions() {
+                                cameraError = error
+                            } else {
+                                showCamera.toggle()
+                            }
+                        }
+                        .alert(isPresented: .constant(cameraError != nil), error: cameraError) { _ in
+                            Button("OK") {
+                                cameraError = nil
+                            }
+                        } message: { error in
+                            Text(error.recoverySuggestion ?? "Try again later")
+                        }
+                        .sheet(isPresented: $showCamera) {
+                            UIKitCamera(selectedImage: $vm.cameraImage)
+                                .ignoresSafeArea()
                         }
                         PhotosPicker(selection: $imagePicker.imageSelection) {
                             Label("Photos", systemImage: "photo")
@@ -45,6 +62,11 @@ struct UpdateEditFormView: View {
             }
             .onAppear {
                 imagePicker.setup(vm)
+            }
+            .onChange(of: vm.cameraImage) {
+                if let image = vm.cameraImage {
+                    vm.data = image.jpegData(compressionQuality: 0.8)
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {

--- a/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
+++ b/Camera Photos SwiftData/Model Edits/UpdateEditFormViewModel.swift
@@ -13,6 +13,7 @@ class UpdateEditFormViewModel {
     var data: Data?
 
     var sample: SampleModel?
+    var cameraImage: UIImage?
 
     var image: UIImage {
         if let data, let uiImage = UIImage(data: data) {

--- a/Camera Photos SwiftData/SampleView.swift
+++ b/Camera Photos SwiftData/SampleView.swift
@@ -17,11 +17,13 @@ struct SampleView: View {
         VStack {
             Text(sample.name)
                 .font(.largeTitle)
-            Image(uiImage: sample.image == nil ? Constants.placeholder : sample.image!)
-                .resizable()
-                .scaledToFit()
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .padding()
+            ZoomableScrollView {
+                Image(uiImage: sample.image == nil ? Constants.placeholder : sample.image!)
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding()
+            }
             HStack {
                 Button("Edit") {
                     formType = .update(sample)


### PR DESCRIPTION
Completed Part3 video tutorial: 3. Camera Photos SwiftData: Camera and Zoomable ScrollView.

This is the 3rd and final video in a series where Stewart Lynch shows how to add a photos picker or choose, and use a camera to take photos and persist those photos to a Swift Data data Store.

In this final video, Stewart Lynch shows how I can access and use my device's camera to take a photo with either the front or back camera.  Stewart also shows how I can quickly add zoom and pan to my photos.

This video also complete 'PhotoAlbum or Camera' series.